### PR TITLE
route_replies: Update to support freenode

### DIFF
--- a/modules/route_replies.cpp
+++ b/modules/route_replies.cpp
@@ -25,7 +25,7 @@ struct reply {
 // TODO this list is far from complete, no errors are handled
 static const struct {
     const char* szRequest;
-    struct reply vReplies[19];
+    struct reply vReplies[20];
 } vRouteReplies[] = {
       {"WHO",
        {{"402", true},   /* rfc1459 ERR_NOSUCHSERVER */
@@ -65,6 +65,7 @@ static const struct {
         {"313", false}, /* rfc1459 RPL_WHOISOPERATOR */
         {"317", false}, /* rfc1459 RPL_WHOISIDLE */
         {"319", false}, /* rfc1459 RPL_WHOISCHANNELS */
+        {"320", false}, /* RPL_WHOISSPECIAL */
         {"301", false}, /* rfc1459 RPL_AWAY */
         {"276", false}, /* oftc-hybrid RPL_WHOISCERTFP */
         {"330", false}, /* ratbox RPL_WHOISLOGGEDIN
@@ -97,6 +98,9 @@ static const struct {
        {{"406", false}, /* rfc1459 ERR_WASNOSUCHNICK */
         {"312", false}, /* rfc1459 RPL_WHOISSERVER */
         {"314", false}, /* rfc1459 RPL_WHOWASUSER */
+        {"330", false}, /* ratbox RPL_WHOISLOGGEDIN
+                           aka ircu RPL_WHOISACCOUNT */
+        {"338", false}, /* RPL_WHOISACTUALLY -- "actually using host" */
         {"369", true},  /* rfc1459 RPL_ENDOFWHOWAS */
         {"431", true},  /* rfc1459 ERR_NONICKNAMEGIVEN */
         {nullptr, true}}},


### PR DESCRIPTION
There were just a couple of messages that weren't accounted for that freenode's ircd sends in response to WHOIS/WHOWAS